### PR TITLE
Add ARM64 support to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-stretch
+FROM openjdk:11.0
 
 LABEL maintainer="haxqer <haxqer666@gmail.com>" version="8.11.0"
 


### PR DESCRIPTION

 #7 
 
The base image of dockerfile is upgraded to **openjdk:11.0** to build the image in **ARM64** platform.


Signed-off-by: odidev <odidev@puresoftware.com>